### PR TITLE
Updated rack 2.2.10 -> 2.2.13 to fix High and medium vulnerabilities …

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (6.0.1)
     racc (1.8.1)
-    rack (2.2.10)
+    rack (2.2.13)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)


### PR DESCRIPTION
Updated rack 2.2.10 -> 2.2.13 to fix High and medium vulnerabilities detected by Dependabot. [Preview Link](https://federalist-92a82776-1dfb-4c5a-9366-896b2f358138.sites.pages.cloud.gov/preview/gsa/icsp/RITM1319021/)

