### PR TITLE
Updated nokogiri 1.17.1 -> 1.18.7 to resolve High vulnerabilties

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    nokogiri (1.17.0-x86_64-linux)
+    nokogiri (1.18.4-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.26.3)
     pathutil (0.16.2)


### PR DESCRIPTION
[Preview Link](https://federalist-92a82776-1dfb-4c5a-9366-896b2f358138.sites.pages.cloud.gov/preview/gsa/icsp/RITM1320063/)