### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,6 @@
 name: Build and test Jekyll USWDS
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/icsp/security/code-scanning/1](https://github.com/GSA/icsp/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function. Based on the workflow's steps, it only needs to read the repository contents (`contents: read`). No write permissions are necessary since the workflow does not modify repository contents or interact with other GitHub features like pull requests or issues.

The `permissions` block will be added immediately after the `name` field at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
